### PR TITLE
Fix Inkscape CLI options

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func (c *Converter) SetBinary(b string) error {
 func (c *Converter) Convert(in []byte) (out []byte, err error) {
 	var stdout, stderr bytes.Buffer
 
-	cmd := exec.Command(c.bin, "-z", "-e", "-", "-f", "-")
+	cmd := exec.Command(c.bin, "-p", "--export-type=png", "-o", "-")
 	cmd.Stdin = bytes.NewBuffer(in)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
Inkscape's CLI options have changed since this was written, which broke it. The Inkscape [CLI wiki page](https://wiki.inkscape.org/wiki/Using_the_Command_Line) has the changes listed. This should have the same behavior, but I'm not an Inkscape expert. I tested it with a few SVGs I had lying around and it worked for all of them, which is a very professional and thorough testing method ;)